### PR TITLE
Fixed keymap syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Add the binds to your `~/.config/yazi/keymap.toml`
 **WARNING:** Make sure the chosen binding isn't already in use!!
 
 ```toml
-[[manager.prepend_keymap]]
-on   = "R"
+[[mgr.prepend_keymap]]
+on   = [ "R" ]
 run  = "plugin rsync"
 desc = "Copy files using rsync"
 ```
@@ -33,8 +33,8 @@ desc = "Copy files using rsync"
 ### Specify Default Remote Server
 
 ```toml
-[[manager.prepend_keymap]]
-on   = "R"
+[[mgr.prepend_keymap]]
+on   = [ "R" ]
 run  = "plugin rsync --args='user@server.com'"
 desc = "Copy files using rsync to default location"
 ```


### PR DESCRIPTION
I just started using yazi and it bugged me quite a lot because it didn't work at fist