### PR TITLE
feat: add --remember option to cache last target

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ run  = "plugin rsync 'user@server.com'"
 desc = "Copy files using rsync to default location"
 ```
 
+### Remember Last Target
+
+Use `--remember` to cache the last used target. On next invocation, the input field will be pre-filled with the cached target.
+
+```toml
+[[mgr.prepend_keymap]]
+on   = [ "R" ]
+run  = "plugin rsync -- --remember"
+desc = "Copy files using rsync (remember target)"
+```
+
+**Note:** The target is stored in `~/.config/yazi/plugins/rsync.yazi/.last_target`
+
 ## Troubleshooting
 
 Basic logging information is sent to `~/.local/state/yazi/yazi.log`

--- a/main.lua
+++ b/main.lua
@@ -49,13 +49,25 @@ return {
 	entry = function(_, job)
 		ya.mgr_emit("escape", { visual = true })
 		local remote_target = job.args and #job.args >= 1 and job.args[1] or nil
+		local remember = job.args and job.args.remember
+
+		local cache_file = os.getenv("HOME") .. "/.config/yazi/plugins/rsync.yazi/.last_target"
+
+		local cached_target = ""
+		if remember then
+			local f = io.open(cache_file, "r")
+			if f then
+				cached_target = f:read("*a"):match("^%s*(.-)%s*$")
+				f:close()
+			end
+		end
 
 		local files = selected_or_hovered()
 		if #files == 0 then
 			return ya.notify({ title = "Rsync", content = "No files selected", level = "warn", timeout = 3 })
 		end
 
-		local default_dest = ""
+		local default_dest = remote_target or cached_target
 		if #files == 1 and remote_target ~= nil then
 			local base_name = files[1]:match("([^/]+)$")
 			default_dest = remote_target .. ":" .. base_name
@@ -112,6 +124,14 @@ return {
 				content = "Rsync Completed!",
 				timeout = 3,
 			})
+
+			if remember and dest and dest ~= "" then
+				local f = io.open(cache_file, "w")
+				if f then
+					f:write(dest)
+					f:close()
+				end
+			end
 		end
 	end,
 }


### PR DESCRIPTION
- Add --remember argument to persist the last used target
- Cache is stored in ~/.config/yazi/plugins/rsync.yazi/.last_target
- Update README with documentation for the new feature